### PR TITLE
👤 feat(backend): 유저 프로필 아바타 추가 및 비밀번호 변경 기능

### DIFF
--- a/apps/backend/src/modules/users/dto/update-profile.dto.ts
+++ b/apps/backend/src/modules/users/dto/update-profile.dto.ts
@@ -17,4 +17,9 @@ export class UpdateProfileDto {
     message: 'nickname must contain only alphanumeric characters or Korean',
   })
   nickname?: string;
+
+  @ApiPropertyOptional({ example: '👤' })
+  @IsOptional()
+  @IsString()
+  avatarUrl?: string;
 }

--- a/apps/backend/src/modules/users/users.controller.ts
+++ b/apps/backend/src/modules/users/users.controller.ts
@@ -30,6 +30,7 @@ import { UsersService } from './users.service';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { SearchUsersDto } from './dto/search-users.dto';
 import { MatchHistoryDto } from './dto/match-history.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
 
 const AVATAR_DIR = path.join(process.cwd(), 'uploads', 'avatars');
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
@@ -67,6 +68,16 @@ export class UsersController {
 
     await this.usersService.update(userId, dto);
     return this.usersService.getProfile(userId);
+  }
+
+  @Patch('me/password')
+  @ApiOperation({ summary: '내 비밀번호 변경' })
+  async updateMyPassword(
+    @CurrentUser('sub') userId: number,
+    @Body() dto: ChangePasswordDto,
+  ) {
+    await this.usersService.changePassword(userId, dto.currentPassword, dto.newPassword);
+    return { message: '비밀번호가 변경되었습니다' };
   }
 
   @Post('me/avatar')

--- a/apps/backend/src/modules/users/users.service.ts
+++ b/apps/backend/src/modules/users/users.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Like } from 'typeorm';
 import { User } from './entities/user.entity';
@@ -220,5 +221,20 @@ export class UsersService {
       loses: u.loses,
       level: u.level,
     }));
+  }
+
+  async changePassword(userId: number, currentPassword: string, newPassword: string) {
+    const user = await this.userRepo.findOne({ where: { userid: userId } });
+    if (!user) throw new NotFoundException('유저를 찾을 수 없습니다');
+
+    if (!user.password) {
+      throw new BadRequestException('OAuth 가입 계정은 비밀번호를 변경할 수 없습니다');
+    }
+
+    const isValid = await bcrypt.compare(currentPassword, user.password);
+    if (!isValid) throw new BadRequestException('현재 비밀번호가 일치하지 않습니다');
+
+    const hashedPassword = await bcrypt.hash(newPassword, 12);
+    await this.userRepo.update(userId, { password: hashedPassword });
   }
 }


### PR DESCRIPTION
# 👤 feat(backend): 유저 프로필 아바타 추가 및 비밀번호 변경 기능

유저 인포메이션 확장 및 보안을 위한 비인증/인증 변경 엔드포인트 세팅을 보강합니다.

## 🔗 관련 이슈 (Related Issues)
- #71: 프로필 명세(`UpdateProfileDto`) `avatarUrl` 필드 옵셔널 추가
- #72: `@Patch('me/password')` 유저 비밀번호 업데이트 컨트롤러 라우팅 주입
- #73: `changePassword` 동작 내 Bcrypt 해싱 비교 및 저장 루틴 복구
