### PR TITLE
🎮 fix(backend): 토너먼트 라운드 결과 연산 및 부전승 예외 가동

### DIFF
--- a/apps/backend/src/modules/game/services/game-result.service.ts
+++ b/apps/backend/src/modules/game/services/game-result.service.ts
@@ -4,6 +4,7 @@ import { Repository, DataSource } from 'typeorm';
 import { Match, MatchStatus } from '../entities/match.entity';
 import { Score } from '../entities/score.entity';
 import { Room, RoomStatus } from '@modules/rooms/entities/room.entity';
+import { RoomMember } from '@modules/rooms/entities/room-member.entity';
 import { Tournament } from '@modules/tournaments/entities/tournament.entity';
 import {
   TournamentParticipant,
@@ -22,10 +23,12 @@ export class GameResultService {
   private onFinalReadyCallback?: (
     roomId: number,
     matchId: number,
+    player1Id?: number,
+    player2Id?: number,
   ) => void;
 
   private onTournamentEventCallback?: (
-    type: 'match:end' | 'match:start' | 'update' | 'end',
+    type: 'match:end' | 'match:start' | 'update' | 'end' | 'room:deleted',
     roomId: number,
     data: any,
   ) => void;
@@ -33,7 +36,7 @@ export class GameResultService {
   private onAchievementCheckCallback?: (userId: number) => void;
 
   setOnFinalReadyCallback(
-    callback: (roomId: number, matchId: number) => void,
+    callback: (roomId: number, matchId: number, player1Id?: number, player2Id?: number) => void,
   ) {
     this.onFinalReadyCallback = callback;
   }
@@ -44,7 +47,7 @@ export class GameResultService {
 
   setOnTournamentEventCallback(
     callback: (
-      type: 'match:end' | 'match:start' | 'update' | 'end',
+      type: 'match:end' | 'match:start' | 'update' | 'end' | 'room:deleted',
       roomId: number,
       data: any,
     ) => void,
@@ -73,9 +76,9 @@ export class GameResultService {
     status: MatchStatus = MatchStatus.FINISHED,
   ): Promise<void> {
     const loserId =
-      winnerId === game.players.player1.userId
-        ? game.players.player2.userId
-        : game.players.player1.userId;
+      Number(winnerId) === Number(game.players.player1.userId)
+        ? Number(game.players.player2.userId)
+        : Number(game.players.player1.userId);
 
     await this.dataSource.transaction(async (manager) => {
       // 1. Update Match
@@ -103,7 +106,7 @@ export class GameResultService {
       );
 
       // 8. Process room/tournament
-      await this.processRoomAfterGame(manager, game);
+      await this.processRoomAfterGame(manager, game, winnerId, loserId);
     });
 
     // 9. Check achievements for both players (after transaction)
@@ -114,7 +117,7 @@ export class GameResultService {
   }
 
   private emitTournamentEvent(
-    type: 'match:end' | 'match:start' | 'update' | 'end',
+    type: 'match:end' | 'match:start' | 'update' | 'end' | 'room:deleted',
     roomId: number,
     data: any,
   ) {
@@ -129,8 +132,8 @@ export class GameResultService {
     opponentId: number,
     isWinner: boolean,
   ): Promise<void> {
-    const user = await this.usersService.findById(userId);
-    const opponent = await this.usersService.findById(opponentId);
+    const user = await manager.query('SELECT * FROM users WHERE userid = ?', [userId]).then((r: any) => r[0]);
+    const opponent = await manager.query('SELECT * FROM users WHERE userid = ?', [opponentId]).then((r: any) => r[0]);
     if (!user || !opponent) return;
 
     // ELO calculation
@@ -164,6 +167,8 @@ export class GameResultService {
   private async processRoomAfterGame(
     manager: any,
     game: GameState,
+    winnerId: number,
+    loserId: number,
   ): Promise<void> {
     const match = await manager
       .getRepository(Match)
@@ -171,7 +176,7 @@ export class GameResultService {
     if (!match) return;
 
     if (!match.tournamentId) {
-      // 1v1: Room → FINISHED
+      // 1v1: Room → FINISHED so back button navigators can read its status before removal!
       await manager
         .getRepository(Room)
         .update({ roomId: game.roomId }, { status: RoomStatus.FINISHED });
@@ -183,10 +188,7 @@ export class GameResultService {
     const participantRepo = manager.getRepository(TournamentParticipant);
     const matchRepo = manager.getRepository(Match);
 
-    const loserId =
-      match.winnerId === game.players.player1.userId
-        ? game.players.player2.userId
-        : game.players.player1.userId;
+
 
     // Eliminate loser
     await participantRepo.update(
@@ -215,6 +217,51 @@ export class GameResultService {
         }
         await matchRepo.save(nextMatch);
 
+        // 3rd Place Match Logic
+        const thirdPlaceMatch = await matchRepo.findOne({
+          where: { tournamentId: match.tournamentId, round: 2, matchOrder: 2 },
+        });
+
+        if (thirdPlaceMatch) {
+          if (match.status !== MatchStatus.WALKOVER) {
+            if (!thirdPlaceMatch.player1Id) {
+              thirdPlaceMatch.player1Id = loserId;
+            } else {
+              thirdPlaceMatch.player2Id = loserId;
+            }
+            await matchRepo.save(thirdPlaceMatch);
+          }
+
+          const round1Matches = await matchRepo.find({
+            where: { tournamentId: match.tournamentId, round: 1 },
+          });
+          
+          const allRound1Finished = round1Matches.every((m: Match) => 
+            [MatchStatus.FINISHED, MatchStatus.WALKOVER, MatchStatus.SURRENDER].includes(m.status)
+          );
+
+          if (allRound1Finished && thirdPlaceMatch.status === MatchStatus.WAITING) {
+            const hasWalkover = round1Matches.some((m: Match) => m.status === MatchStatus.WALKOVER);
+            if (!hasWalkover && thirdPlaceMatch.player1Id && thirdPlaceMatch.player2Id) {
+              this.emitTournamentEvent('match:start', game.roomId, {
+                matchId: thirdPlaceMatch.matchId,
+                player1Id: thirdPlaceMatch.player1Id,
+                player2Id: thirdPlaceMatch.player2Id,
+                round: 2,
+              });
+
+              if (this.onFinalReadyCallback) {
+                this.onFinalReadyCallback(
+                  game.roomId, 
+                  thirdPlaceMatch.matchId, 
+                  thirdPlaceMatch.player1Id!, 
+                  thirdPlaceMatch.player2Id!
+                );
+              }
+            }
+          }
+        }
+
         // Emit tournament:update after winner assignment
         this.emitTournamentEvent('update', game.roomId, {
           tournamentId: match.tournamentId,
@@ -239,29 +286,116 @@ export class GameResultService {
             this.onFinalReadyCallback(
               game.roomId,
               nextMatch.matchId,
+              nextMatch.player1Id!,
+              nextMatch.player2Id!
             );
           }
         }
       }
     } else if (match.round === 2) {
-      // Final match done
-      await tournamentRepo.update(match.tournamentId, {
-        isFinish: true,
-        winnerId: match.winnerId,
+      const matchRepo = manager.getRepository(Match);
+      const matches = await matchRepo.find({
+        where: { tournamentId: match.tournamentId, round: 2 },
       });
-      await participantRepo.update(
-        { tournamentId: match.tournamentId, userId: match.winnerId! },
-        { status: ParticipantStatus.WINNER },
-      );
-      await manager
-        .getRepository(Room)
-        .update({ roomId: game.roomId }, { status: RoomStatus.FINISHED });
+      const finalMatch = matches.find((m: Match) => m.matchOrder === 1);
+      const thirdPlaceMatch = matches.find((m: Match) => m.matchOrder === 2);
 
-      // Emit tournament:end
-      this.emitTournamentEvent('end', game.roomId, {
-        tournamentId: match.tournamentId,
-        winnerId: match.winnerId,
+      const isFinalDone =
+        finalMatch &&
+        [MatchStatus.FINISHED, MatchStatus.WALKOVER, MatchStatus.SURRENDER].includes(finalMatch.status);
+      const isThirdDone =
+        thirdPlaceMatch &&
+        [MatchStatus.FINISHED, MatchStatus.WALKOVER, MatchStatus.SURRENDER].includes(thirdPlaceMatch.status);
+
+      const round1Matches = await matchRepo.find({
+        where: { tournamentId: match.tournamentId, round: 1 },
       });
+      const hasWalkover = round1Matches.some((m: Match) => m.status === MatchStatus.WALKOVER);
+
+      // If walkover happened in semi-finals, we don't need 3rd place match to end tournament
+      const shouldCheckThirdPlace = !hasWalkover;
+
+      if (isFinalDone && (!shouldCheckThirdPlace || isThirdDone)) {
+        const firstId = finalMatch.winnerId;
+        const secondId =
+          finalMatch.player1Id === firstId ? finalMatch.player2Id : finalMatch.player1Id;
+
+        let thirdId = null;
+        let fourthId = null;
+
+        if (hasWalkover) {
+          const walkoverMatch = round1Matches.find((m: Match) => m.status === MatchStatus.WALKOVER);
+          const normalMatch = round1Matches.find((m: Match) => m.status === MatchStatus.FINISHED || m.status === MatchStatus.SURRENDER);
+          
+          if (walkoverMatch) {
+            fourthId = walkoverMatch.player1Id === walkoverMatch.winnerId ? walkoverMatch.player2Id : walkoverMatch.player1Id;
+          }
+          if (normalMatch) {
+            thirdId = normalMatch.player1Id === normalMatch.winnerId ? normalMatch.player2Id : normalMatch.player1Id;
+          }
+        } else {
+          thirdId = thirdPlaceMatch ? thirdPlaceMatch.winnerId : null;
+          fourthId = thirdPlaceMatch
+            ? thirdPlaceMatch.player1Id === thirdId
+              ? thirdPlaceMatch.player2Id
+              : thirdPlaceMatch.player1Id
+            : null;
+        }
+
+        const ranks = {
+          first: firstId ? await this.usersService.getPublicProfile(firstId) : null,
+          second: secondId ? await this.usersService.getPublicProfile(secondId) : null,
+          third: thirdId ? await this.usersService.getPublicProfile(thirdId) : null,
+          fourth: fourthId ? await this.usersService.getPublicProfile(fourthId) : null,
+        };
+
+        const rankings = {
+          first: ranks.first
+            ? { id: ranks.first.userid, username: ranks.first.nickname, avatar: ranks.first.avatarUrl }
+            : null,
+          second: ranks.second
+            ? { id: ranks.second.userid, username: ranks.second.nickname, avatar: ranks.second.avatarUrl }
+            : null,
+          third: ranks.third
+            ? { id: ranks.third.userid, username: ranks.third.nickname, avatar: ranks.third.avatarUrl }
+            : null,
+          fourth: ranks.fourth
+            ? { id: ranks.fourth.userid, username: ranks.fourth.nickname, avatar: ranks.fourth.avatarUrl }
+            : null,
+        };
+
+        if (finalMatch.tournamentId) {
+          await tournamentRepo.update(finalMatch.tournamentId, {
+            isFinish: true,
+            winnerId: firstId,
+          });
+
+          if (firstId) {
+            await participantRepo.update(
+              { tournamentId: finalMatch.tournamentId, userId: firstId },
+              { status: ParticipantStatus.WINNER },
+            );
+          }
+        }
+
+        await manager.getRepository(RoomMember).delete({ roomId: game.roomId });
+        await manager.getRepository(Room).delete({ roomId: game.roomId });
+        this.emitTournamentEvent('room:deleted', game.roomId, { roomId: game.roomId });
+
+        this.emitTournamentEvent('end', game.roomId, {
+          tournamentId: match.tournamentId,
+          rankings,
+        });
+      } else {
+        // Just emit update for client to know one is done
+        this.emitTournamentEvent('update', game.roomId, {
+          tournamentId: match.tournamentId,
+        });
+      }
     }
+  }
+
+  async getMatch(matchId: number) {
+    return this.matchRepo.findOne({ where: { matchId } });
   }
 }

--- a/apps/backend/src/modules/game/services/pong-engine.service.ts
+++ b/apps/backend/src/modules/game/services/pong-engine.service.ts
@@ -31,10 +31,12 @@ export class PongEngineService {
     roomId: number,
     player1Id: number,
     player2Id: number,
+    isTournament: boolean,
   ): GameState {
     const game: GameState = {
       matchId,
       roomId,
+      isTournament,
       status: 'countdown',
       ball: this.createInitialBall(),
       players: {
@@ -79,6 +81,18 @@ export class PongEngineService {
       if (
         game.players.player1.userId === userId ||
         game.players.player2.userId === userId
+      ) {
+        return game;
+      }
+    }
+    return undefined;
+  }
+
+  findGameBySocketId(socketId: string): GameState | undefined {
+    for (const game of this.games.values()) {
+      if (
+        game.players.player1.socketId === socketId ||
+        game.players.player2.socketId === socketId
       ) {
         return game;
       }
@@ -311,7 +325,7 @@ export class PongEngineService {
     };
   }
 
-  private clearGameLoop(matchId: number): void {
+  public clearGameLoop(matchId: number): void {
     const interval = this.gameLoops.get(matchId);
     if (interval) {
       clearInterval(interval);
@@ -319,7 +333,7 @@ export class PongEngineService {
     }
   }
 
-  private clearBroadcastLoop(matchId: number): void {
+  public clearBroadcastLoop(matchId: number): void {
     const interval = this.broadcastLoops.get(matchId);
     if (interval) {
       clearInterval(interval);


### PR DESCRIPTION
# 🎮 fix(backend): 토너먼트 라운드 결과 연산 및 부전승 예외 가동

토너먼트 4강 종료 시점의 시퀀스 계산과 스코어보드 전송 처리를 보완합니다.

## 🔗 관련 이슈 (Related Issues)
- #79: 4강전(Round 1) 종료 단에서 3/4위전 매치의 오토 스타팅(`match:start`) 트리거 가동
- #80: 부전승(Walkover) 발생 시 3위전 불성립 예외 필터링 및 직접 결승 연결
- #81: 최종 1~4위 스케일링 프로필 묶음 보정 및 동적 데이터 레이킹
- #82: `pong-engine.service.ts` 소켓 ID 전개 게임 세션 트래커 `findGameBySocketId` 빌딩
- #83: 수거 메서드 `clearGameLoop`를 `public`으로 개방 접근
