### PR TITLE
feat: Auth Flow Improvements & Local Game Navigation

### DIFF
--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -19,6 +19,7 @@ import { FtOAuthService } from './strategies/ft-oauth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 import { JwtAuthGuard } from '@common/guards/jwt-auth.guard';
 import { CurrentUser } from '@common/decorators/current-user.decorator';
 
@@ -44,6 +45,13 @@ export class AuthController {
   @ApiOperation({ summary: '로그인' })
   async login(@Body() _dto: LoginDto, @Request() req: any) {
     return this.authService.login(req.user);
+  }
+
+  @Post('reset-password')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: '비밀번호 분실 초기화' })
+  async resetPassword(@Body() dto: ResetPasswordDto) {
+    return this.authService.resetPassword(dto);
   }
 
   @Post('refresh')

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -9,6 +9,7 @@ import * as bcrypt from 'bcrypt';
 import { UsersService } from '@modules/users/users.service';
 import { User } from '@modules/users/entities/user.entity';
 import { RegisterDto } from './dto/register.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 
 @Injectable()
 export class AuthService {
@@ -91,6 +92,20 @@ export class AuthService {
         avatarUrl: user.avatarUrl,
       },
     };
+  }
+
+  async resetPassword(dto: ResetPasswordDto) {
+    const user = await this.usersService.findByEmail(dto.email);
+    if (!user) {
+      throw new ConflictException('해당 이메일로 가입된 계정이 없습니다');
+    }
+    if (user.oauthProvider) {
+      throw new ConflictException('OAuth로 가입된 계정은 비밀번호를 변경할 수 없습니다');
+    }
+
+    const hashedPassword = await bcrypt.hash(dto.newPassword, 12);
+    await this.usersService.update(user.userid, { password: hashedPassword });
+    return { message: '비밀번호가 성공적으로 변경되었습니다' };
   }
 
   async refreshTokens(refreshToken: string) {

--- a/apps/backend/src/modules/auth/dto/reset-password.dto.ts
+++ b/apps/backend/src/modules/auth/dto/reset-password.dto.ts
@@ -1,0 +1,13 @@
+import { IsEmail, IsString, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResetPasswordDto {
+  @ApiProperty({ example: 'user@example.com', description: '가입된 이메일' })
+  @IsEmail()
+  email!: string;
+
+  @ApiProperty({ example: 'new_password123', description: '새 비밀번호 (6자 이상)' })
+  @IsString()
+  @MinLength(6)
+  newPassword!: string;
+}

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route } from 'react-router-dom';
-import { Home, GamePage, OnlineGame, Login, Register, Profile, Settings, Leaderboard, Friends, PrivacyPolicy, TermsOfService, NotFound, LobbyList, RoomView } from './pages';
+import { Home, GamePage, OnlineGame, Login, Register, Profile, Settings, Leaderboard, Friends, PrivacyPolicy, TermsOfService, NotFound, LobbyList, RoomView, ForgotPassword, AuthCallback } from './pages';
 import { AuthProvider } from './contexts/AuthContext';
 
 function App() {
@@ -8,7 +8,9 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/auth/callback" element={<AuthCallback />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/profile" element={<Profile />} />
         <Route path="/profile/:id" element={<Profile />} />
         <Route path="/settings" element={<Settings />} />

--- a/apps/frontend/src/components/Game/Game.tsx
+++ b/apps/frontend/src/components/Game/Game.tsx
@@ -1,4 +1,5 @@
 import { useRef, useCallback, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useGameLoop } from '../../hooks/useGameLoop';
 import { useKeyboard } from '../../hooks/useKeyboard';
 import { LocalGameCanvas } from './LocalGameCanvas';
@@ -80,9 +81,15 @@ export function Game() {
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 flex items-center justify-center p-4 sm:p-8">
       <div className="flex flex-col items-center gap-4 sm:gap-8 w-full max-w-7xl">
         {/* Title and Settings Button */}
-        <div className="flex items-center gap-4">
-          <div className="flex items-center">
-            <img src="/logo.png" className="h-16 sm:h-20 w-auto" alt="Xerath" />
+        <div className="flex items-center gap-4 w-full justify-between">
+          <div className="flex items-center gap-4">
+            <Link
+              to="/"
+              className="px-4 py-2 bg-gray-800 hover:bg-gray-700 text-white font-semibold rounded-lg transition-colors border border-gray-700 flex items-center gap-2"
+            >
+              <span>←</span> Home
+            </Link>
+            <img src="/logo.png" className="h-16 sm:h-20 w-auto hidden sm:block" alt="Xerath" />
           </div>
           <button
             onClick={() => setShowSettings(true)}

--- a/apps/frontend/src/pages/AuthCallback.tsx
+++ b/apps/frontend/src/pages/AuthCallback.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { setTokens } from '../api/client';
+
+export function AuthCallback() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { checkAuth } = useAuth();
+
+  useEffect(() => {
+    const accessToken = searchParams.get('accessToken');
+    const refreshToken = searchParams.get('refreshToken');
+
+    if (accessToken && refreshToken) {
+      setTokens(accessToken, refreshToken);
+      checkAuth().then(() => {
+        navigate('/');
+      });
+    } else {
+      console.error('Missing tokens in callback URL');
+      navigate('/login');
+    }
+  }, [searchParams, navigate, checkAuth]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-blue-900 to-gray-900 flex items-center justify-center p-4">
+      <div className="text-center">
+        <div className="inline-block animate-spin rounded-full h-16 w-16 border-t-2 border-b-2 border-blue-500 mb-4"></div>
+        <p className="text-white text-xl font-semibold">인증 중입니다...</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/ForgotPassword.tsx
+++ b/apps/frontend/src/pages/ForgotPassword.tsx
@@ -1,0 +1,108 @@
+import { useState, FormEvent } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { apiFetch } from '../api/client';
+
+export function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+    setLoading(true);
+
+    try {
+      const res = await apiFetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, newPassword }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message || '비밀번호 초기화 실패');
+      }
+
+      setSuccess('비밀번호가 성공적으로 변경되었습니다. 로그인 페이지로 이동합니다.');
+      setTimeout(() => navigate('/login'), 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '비밀번호 초기화 중 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-blue-900 to-gray-900 flex items-center justify-center p-4">
+      <div className="max-w-md w-full bg-gray-800 rounded-lg shadow-xl p-8">
+        <h1 className="text-3xl font-bold text-white mb-2 text-center">Reset Password</h1>
+        <p className="text-gray-400 text-center mb-8">가입하신 이메일과 새로운 비밀번호를 입력해주세요.</p>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-500/20 border border-red-500 rounded-lg text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+        {success && (
+          <div className="mb-4 p-3 bg-green-500/20 border border-green-500 rounded-lg text-green-400 text-sm">
+            {success}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-2">
+              Registered Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full px-4 py-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:outline-none focus:border-blue-500 transition-colors"
+              placeholder="your@email.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="newPassword" className="block text-sm font-medium text-gray-300 mb-2">
+              New Password
+            </label>
+            <input
+              id="newPassword"
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              required
+              minLength={6}
+              className="w-full px-4 py-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:outline-none focus:border-blue-500 transition-colors"
+              placeholder="최소 6자 이상"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading || !!success}
+            className="w-full py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 text-white font-semibold rounded-lg transition-colors mt-6"
+          >
+            {loading ? 'Changing...' : 'Reset Password'}
+          </button>
+        </form>
+
+        <div className="mt-6 text-center">
+          <Link to="/login" className="text-gray-400 hover:text-white text-sm transition-colors">
+            ← Back to Login
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/Login.tsx
+++ b/apps/frontend/src/pages/Login.tsx
@@ -76,6 +76,12 @@ export function Login() {
             />
           </div>
 
+          <div className="flex justify-end">
+            <Link to="/forgot-password" className="text-sm text-gray-400 hover:text-white transition-colors">
+              Forgot Password?
+            </Link>
+          </div>
+
           <button
             type="submit"
             disabled={loading}

--- a/apps/frontend/src/pages/index.ts
+++ b/apps/frontend/src/pages/index.ts
@@ -12,3 +12,5 @@ export * from './TermsOfService';
 export * from './NotFound';
 export * from './LobbyList';
 export * from './RoomView';
+export * from './ForgotPassword';
+export * from './AuthCallback';


### PR DESCRIPTION
## Overview
This PR addresses 3 distinct feature requests for the authentication flow and local game navigation.

## Changes Made
### Local Game Navigation
- Added a `← Home` navigation button inside the `<Game />` component to allow users to exit the local game.

### Password Reset Flow
- Added a `POST /api/auth/reset-password` endpoint on the backend (`auth.controller` & `auth.service`).
- Created a `<ForgotPassword />` page on the frontend and linked it from `<Login />`.

### 42 OAuth Callback
- Added `<AuthCallback />` route to cleanly parse OAuth redirection tokens (`accessToken`, `refreshToken`) from query parameters, store them, and redirect to Home.

**Fixes:** #99, #100, #101