### PR TITLE
feat: add nginx SSL reverse proxy for localhost HTTPS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    ports:
-      - "3001:3001"
+    expose:
+      - "3001"
     restart: unless-stopped
 
   frontend:
@@ -40,8 +40,23 @@ services:
       - .env
     depends_on:
       - backend
+    expose:
+      - "3000"
+
+  nginx:
+    image: nginx:alpine
     ports:
-      - "3000:3000"
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./infra/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./infra/nginx/init-certs.sh:/docker-entrypoint.d/init-certs.sh:ro
+      - nginx_certs:/etc/nginx/certs
+    entrypoint: ["sh", "/docker-entrypoint.d/init-certs.sh"]
+    depends_on:
+      - frontend
+      - backend
+    restart: unless-stopped
 
   prometheus:
     image: prom/prometheus:latest
@@ -71,3 +86,4 @@ services:
 volumes:
   db_data:
   grafana_data:
+  nginx_certs:

--- a/infra/nginx/init-certs.sh
+++ b/infra/nginx/init-certs.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+CERT_DIR="/etc/nginx/certs"
+if [ ! -f "$CERT_DIR/server.crt" ]; then
+    mkdir -p "$CERT_DIR"
+    openssl req -x509 -nodes -days 365 \
+        -newkey rsa:2048 \
+        -keyout "$CERT_DIR/server.key" \
+        -out "$CERT_DIR/server.crt" \
+        -subj "/C=KR/ST=Seoul/L=Seoul/O=Transcendence/CN=localhost" \
+        -addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1"
+    echo "SSL certificates generated."
+else
+    echo "SSL certificates already exist, skipping generation."
+fi
+exec nginx -g 'daemon off;'

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,49 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    # HTTP -> HTTPS redirect
+    server {
+        listen 80;
+        server_name localhost;
+        return 301 https://$host$request_uri;
+    }
+
+    # HTTPS
+    server {
+        listen 443 ssl;
+        server_name localhost;
+
+        ssl_certificate     /etc/nginx/certs/server.crt;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+
+        # Frontend
+        location / {
+            proxy_pass http://frontend:3000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Backend API
+        location /api/ {
+            proxy_pass http://backend:3001/api/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # WebSocket
+        location /socket.io/ {
+            proxy_pass http://backend:3001/socket.io/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- nginx 리버스 프록시 설정을 추가했습니다. (openssl로 SSL 인증 기능 추가)
- 프론트랑 백엔드 포트가 더이상 직접 노출되지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)