### PR TITLE
feat: 커스텀 Prometheus 메트릭 수집 연결

### DIFF
--- a/apps/backend/src/common/guards/api-key.guard.ts
+++ b/apps/backend/src/common/guards/api-key.guard.ts
@@ -6,10 +6,14 @@ import {
 } from '@nestjs/common';
 import { createHash } from 'crypto';
 import { ApiKeysService } from '@modules/api-keys/api-keys.service';
+import { MetricsService } from '@modules/monitoring/metrics.service';
 
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
-  constructor(private readonly apiKeysService: ApiKeysService) {}
+  constructor(
+    private readonly apiKeysService: ApiKeysService,
+    private readonly metricsService: MetricsService,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
@@ -31,6 +35,7 @@ export class ApiKeyGuard implements CanActivate {
     }
 
     this.apiKeysService.updateLastUsed(apiKey.apiKeyId);
+    this.metricsService.incApiKeyRequests();
 
     request.apiKeyUser = { userId: apiKey.userId };
 

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -8,6 +8,7 @@ import { ConfigService } from '@nestjs/config';
 import * as bcrypt from 'bcrypt';
 import { UsersService } from '@modules/users/users.service';
 import { User } from '@modules/users/entities/user.entity';
+import { MetricsService } from '@modules/monitoring/metrics.service';
 import { RegisterDto } from './dto/register.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 
@@ -17,6 +18,7 @@ export class AuthService {
     private readonly usersService: UsersService,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
+    private readonly metricsService: MetricsService,
   ) {}
 
   async register(dto: RegisterDto) {
@@ -40,6 +42,8 @@ export class AuthService {
       nickname: dto.nickname,
     });
 
+    this.metricsService.incRegistrations();
+
     return {
       userid: user.userid,
       email: user.email,
@@ -50,10 +54,12 @@ export class AuthService {
   async validateUser(email: string, password: string) {
     const user = await this.usersService.findByEmail(email);
     if (!user) {
+      this.metricsService.incLogins('failure');
       throw new UnauthorizedException('이메일 또는 비밀번호가 올바르지 않습니다');
     }
 
     if (!user.password) {
+      this.metricsService.incLogins('failure');
       throw new UnauthorizedException(
         'OAuth로 가입된 계정입니다. OAuth 로그인을 이용해주세요',
       );
@@ -61,6 +67,7 @@ export class AuthService {
 
     const isPasswordValid = await bcrypt.compare(password, user.password);
     if (!isPasswordValid) {
+      this.metricsService.incLogins('failure');
       throw new UnauthorizedException('이메일 또는 비밀번호가 올바르지 않습니다');
     }
 
@@ -81,6 +88,8 @@ export class AuthService {
 
     const hashedRefreshToken = await bcrypt.hash(refreshToken, 10);
     await this.usersService.update(user.userid, { hashedRefreshToken });
+
+    this.metricsService.incLogins('success');
 
     return {
       accessToken,

--- a/apps/backend/src/modules/game/gateways/game.gateway.ts
+++ b/apps/backend/src/modules/game/gateways/game.gateway.ts
@@ -21,6 +21,7 @@ import { GameResultService } from '../services/game-result.service';
 import { UsersService } from '@modules/users/users.service';
 import { LobbyGateway } from '@modules/rooms/gateways/lobby.gateway';
 import { AchievementsService } from '@modules/achievements/achievements.service';
+import { MetricsService } from '@modules/monitoring/metrics.service';
 import { GAME_CONFIG } from '../constants/game.constants';
 
 @WebSocketGateway({ namespace: '/game', cors: true })
@@ -43,6 +44,7 @@ export class GameGateway
     @Inject(forwardRef(() => LobbyGateway))
     private readonly lobbyGateway: LobbyGateway,
     private readonly achievementsService: AchievementsService,
+    private readonly metricsService: MetricsService,
     @InjectRepository(Match)
     private readonly matchRepo: Repository<Match>,
   ) {}
@@ -132,6 +134,14 @@ export class GameGateway
         try {
           const match = await this.gameResultService.getMatch(matchId);
           await this.gameResultService.processGameEnd(game, winnerId);
+
+          this.metricsService.incMatchesTotal();
+          if (match?.startAt) {
+            const durationSec = (Date.now() - new Date(match.startAt).getTime()) / 1000;
+            this.metricsService.observeMatchDuration(durationSec);
+          }
+          this.metricsService.setActiveMatches(this.pongEngine.getActiveGameCount());
+
           if (!game.isTournament) {
             this.server.emit('room:deleted', { roomId: game.roomId });
           }
@@ -160,6 +170,7 @@ export class GameGateway
       const payload = this.jwtService.verify<JwtPayload>(token);
       this.socketUser.set(client.id, payload.sub);
       this.userSocket.set(payload.sub, client.id);
+      this.metricsService.setWebSocketConnections(this.socketUser.size);
     } catch {
       client.disconnect();
     }
@@ -168,6 +179,7 @@ export class GameGateway
   handleDisconnect(client: Socket) {
     const userId = this.socketUser.get(client.id);
     this.socketUser.delete(client.id);
+    this.metricsService.setWebSocketConnections(this.socketUser.size);
     if (!userId) return;
 
     this.userSocket.delete(userId);
@@ -276,6 +288,7 @@ export class GameGateway
         match.player2Id!,
         !!match.tournamentId,
       );
+      this.metricsService.setActiveMatches(this.pongEngine.getActiveGameCount());
     }
 
     const player =

--- a/apps/backend/src/modules/game/services/game-result.service.ts
+++ b/apps/backend/src/modules/game/services/game-result.service.ts
@@ -11,6 +11,7 @@ import {
   ParticipantStatus,
 } from '@modules/tournaments/entities/tournament-participant.entity';
 import { UsersService } from '@modules/users/users.service';
+import { MetricsService } from '@modules/monitoring/metrics.service';
 import { GameState } from '../interfaces/game-state.interface';
 
 const ELO_K_FACTOR = 32;
@@ -67,6 +68,7 @@ export class GameResultService {
     @InjectRepository(TournamentParticipant)
     private readonly participantRepo: Repository<TournamentParticipant>,
     private readonly usersService: UsersService,
+    private readonly metricsService: MetricsService,
     private readonly dataSource: DataSource,
   ) {}
 
@@ -369,6 +371,8 @@ export class GameResultService {
             isFinish: true,
             winnerId: firstId,
           });
+          const activeCount = await this.tournamentRepo.count({ where: { isFinish: false } });
+          this.metricsService.setActiveTournaments(activeCount);
 
           if (firstId) {
             await participantRepo.update(

--- a/apps/backend/src/modules/game/services/pong-engine.service.ts
+++ b/apps/backend/src/modules/game/services/pong-engine.service.ts
@@ -136,6 +136,10 @@ export class PongEngineService {
     this.games.delete(matchId);
   }
 
+  getActiveGameCount(): number {
+    return this.games.size;
+  }
+
   getMinimizedState(game: GameState): MinimizedGameState {
     return {
       b: { x: game.ball.x, y: game.ball.y },

--- a/apps/backend/src/modules/monitoring/monitoring.module.ts
+++ b/apps/backend/src/modules/monitoring/monitoring.module.ts
@@ -1,7 +1,8 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { MetricsService } from './metrics.service';
 import { MetricsController } from './metrics.controller';
 
+@Global()
 @Module({
   controllers: [MetricsController],
   providers: [MetricsService],

--- a/apps/backend/src/modules/rooms/rooms.service.ts
+++ b/apps/backend/src/modules/rooms/rooms.service.ts
@@ -15,6 +15,7 @@ import { Match, MatchStatus } from '@modules/game/entities/match.entity';
 import { Tournament } from '@modules/tournaments/entities/tournament.entity';
 import { TournamentParticipant } from '@modules/tournaments/entities/tournament-participant.entity';
 import { UsersService } from '@modules/users/users.service';
+import { MetricsService } from '@modules/monitoring/metrics.service';
 import { LobbyGateway } from './gateways/lobby.gateway';
 import { CreateRoomDto } from './dto/create-room.dto';
 
@@ -32,6 +33,7 @@ export class RoomsService {
     @InjectRepository(TournamentParticipant)
     private readonly participantRepo: Repository<TournamentParticipant>,
     private readonly usersService: UsersService,
+    private readonly metricsService: MetricsService,
     private readonly dataSource: DataSource,
     @Inject(forwardRef(() => LobbyGateway))
     private readonly lobbyGateway: LobbyGateway,
@@ -57,6 +59,7 @@ export class RoomsService {
 
     const result = await this.findOne(savedRoom.roomId);
     this.lobbyGateway.emitRoomCreated(result);
+    this.metricsService.setActiveRooms(await this.roomRepo.count({ where: { status: RoomStatus.WAITING } }));
     return result;
   }
 
@@ -184,6 +187,7 @@ export class RoomsService {
     await this.memberRepo.delete({ roomId });
     await this.roomRepo.remove(room);
     this.lobbyGateway.emitRoomDeleted(roomId);
+    this.metricsService.setActiveRooms(await this.roomRepo.count({ where: { status: RoomStatus.WAITING } }));
   }
 
   async join(roomId: number, userId: number) {
@@ -274,6 +278,7 @@ export class RoomsService {
       if (room.countPlayers <= 0) {
         await roomRepo.remove(room);
         this.lobbyGateway.emitRoomDeleted(roomId);
+        this.metricsService.setActiveRooms(await this.roomRepo.count({ where: { status: RoomStatus.WAITING } }));
         return { roomId, userId, roomDeleted: true };
       }
 
@@ -386,6 +391,9 @@ export class RoomsService {
       currentRound: 1,
     });
     const savedTournament = await this.tournamentRepo.save(tournament);
+    this.metricsService.setActiveTournaments(
+      await this.tournamentRepo.count({ where: { isFinish: false } }),
+    );
 
     for (const member of members) {
       const participant = this.participantRepo.create({


### PR DESCRIPTION
## 요약
- 정의만 되어 있고 호출되지 않던 `MetricsService`의 커스텀 메트릭 메서드들을 실제 비즈니스 로직에 연결
- `MonitoringModule`에 `@Global()` 데코레이터를 추가하여 모든 모듈에서 별도 import 없이 `MetricsService` 주입 가능
- Grafana 대시보드에서 실제 데이터가 표시되도록 수정

## 변경 내용
| 모듈 | 메트릭 | 호출 위치 |
|------|--------|----------|
| Auth | `user_registrations_total` | 회원가입 성공 시 |
| Auth | `auth_login_total{result}` | 로그인 성공/실패 시 |
| Game Gateway | `websocket_connections_total` | WS 연결/해제 시 |
| Game Gateway | `game_active_matches` | 매치 생성/종료 시 |
| Game Gateway | `game_matches_total` | 매치 완료 시 |
| Game Gateway | `game_match_duration_seconds` | 매치 종료 시 소요 시간 기록 |
| Rooms | `rooms_active_total` | 방 생성/삭제 시 |
| Rooms / GameResult | `game_active_tournaments` | 토너먼트 시작/종료 시 |
| API Key Guard | `api_key_requests_total` | API 키 인증 성공 시 |

## 테스트 방법
- [ ] `npx tsc --noEmit` 타입 체크 통과 (spec 파일 제외)
- [ ] `npx jest --testPathPattern="monitoring"` 기존 모니터링 테스트 통과
- [ ] `docker compose up` 후 `curl localhost:3001/metrics`에서 커스텀 메트릭 값 확인
- [ ] Grafana 대시보드(Game Metrics, User Metrics)에서 실제 데이터 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)